### PR TITLE
Fixed link to home page

### DIFF
--- a/gophertown.org/static/js/router.js
+++ b/gophertown.org/static/js/router.js
@@ -1,8 +1,8 @@
 GopherTown.Router.map(function() {
-  this.resource('index', { path: '/' });
+  this.resource('index', { path: '/index.html' });
 });
 GopherTown.Router.map(function() {
-  this.resource('index', { path: '/index.html' });
+  this.resource('index', { path: '/' });
 });
 
 GopherTown.Router.map(function() {
@@ -52,7 +52,7 @@ GopherTown.ApplicationRoute = Ember.Route.extend({
 GopherTown.RandomRoute = Ember.Route.extend({
   model: function(params) {
     return jQuery.getJSON('/gophers/random').then(function(res) {
-        console.log(res)
+        console.log(res);
       return { results: res };
     });
   }


### PR DESCRIPTION
In a gopher's details page, the link back to the front page goes to `/index.html`, and not simply `/`. I'm not sure how Ember works, but it seems to take the last defined path for a resource when doing `{{#link-to 'index'}}`. Reversing the order of the `Router.map()` calls seems to fix this.
